### PR TITLE
Remove sudo from action.sh

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -20,7 +20,7 @@ npm init -y && npm install -y postcss postcss-cli autoprefixer
 echo '🤵 Install Hugo'
 mkdir tmp/ && cd tmp/
 curl -sSL $(curl -s https://api.github.com/repos/gohugoio/hugo/releases/latest | grep "browser_download_url.*\hugo_extended.*\_Linux-64bit.tar.gz" | rev | cut -d ' ' -f 1 | rev | tr -d '"') | tar -xvzf-
-sudo mv hugo /usr/local/bin/
+mv hugo /usr/local/bin/
 cd .. && rm -rf tmp/
 cd ${GITHUB_WORKSPACE}
 hugo version || exit 1


### PR DESCRIPTION
Builds failed with this error:
```
/action.sh: line 23: sudo: command not found
```

Removing the `sudo` seems to fix the issue.